### PR TITLE
fix: :bug: `useBackend`の仕様

### DIFF
--- a/app/lib/compositions.ts
+++ b/app/lib/compositions.ts
@@ -8,19 +8,32 @@ type NestedRefs<T> = {
 
 type BackendCall = (...params: any[]) => Promise<APIResponse<any>>;
 type BackendCallParameters<T extends BackendCall> = T extends (...args: infer P) => any ? NestedRefs<P> : never;
+/**
+ * Return type of backend call, basically same as `APIResponse<T>`.
+ */
 type BackendCallResponse<T extends BackendCall> = ReturnType<T> extends Promise<infer I> ? I : APIResponse;
 
 /**
+ * @param call network function.
+ * @param immediately whether to invoke the network function immediately on mounted.
+ * @param args parameters to call the function.
+ * @returns
  * @example
- * const { data, error } = useBackend(getUserInfo("IdOfUser"))
+ * const foo = ref("foo")
+ * const bar = ref("bar")
+ *
+ * const { data, error, refresh } = UseBackend(backendCall, true, foo, bar); // will call backendCall(foo, bar)
+ * // data will be filled if backend server responded normally.
+ * // error will be filled if backend server responded error.
+ * // refresh is a function to be call to fetch backend server again.
  */
-export const useBackend = <T extends BackendCall>(call: T, immediately = true, ...params: BackendCallParameters<T>) => {
+export const useBackend = <T extends BackendCall>(call: T, immediately = true, ...args: BackendCallParameters<T>) => {
   const data = shallowRef<BackendCallResponse<T>>();
   const error = shallowRef<ErrorResponse>();
-  const param = reactive(params);
+  const params = reactive(args);
 
   const refresh = () =>
-    call(...param)
+    call(...params)
       .then((res) => {
         data.value = res;
         error.value = undefined;

--- a/app/lib/compositions.ts
+++ b/app/lib/compositions.ts
@@ -21,8 +21,14 @@ export const useBackend = <T extends BackendCall>(call: T, immediately = true, .
 
   const refresh = () =>
     call(...param)
-      .then((res) => (data.value = res))
-      .catch((err) => (error.value = err));
+      .then((res) => {
+        data.value = res;
+        error.value = undefined;
+      })
+      .catch((err) => {
+        error.value = err;
+        data.value = undefined;
+      });
 
   if (immediately) {
     onMounted(refresh);

--- a/app/lib/compositions.ts
+++ b/app/lib/compositions.ts
@@ -1,4 +1,4 @@
-import { reactive, Ref, shallowRef } from "vue";
+import { onMounted, reactive, Ref, shallowRef } from "vue";
 
 import { APIResponse, ErrorResponse } from "./network";
 
@@ -24,7 +24,9 @@ export const useBackend = <T extends BackendCall>(call: T, immediately = true, .
       .then((res) => (data.value = res))
       .catch((err) => (error.value = err));
 
-  immediately ? refresh() : undefined;
+  if (immediately) {
+    onMounted(refresh);
+  }
 
   return { data, error, refresh };
 };

--- a/app/lib/compositions.ts
+++ b/app/lib/compositions.ts
@@ -1,17 +1,26 @@
-import { shallowRef } from "vue";
+import { reactive, Ref, shallowRef } from "vue";
 
-import { BackendCall, APIResponse, ErrorResponse } from "./network";
+import { APIResponse, ErrorResponse } from "./network";
+
+type NestedRefs<T> = {
+  [key in keyof T]: T[key] extends object ? NestedRefs<T[key]> : Ref<T[key]>;
+};
+
+type BackendCall = (...params: any[]) => Promise<APIResponse<any>>;
+type BackendCallParameters<T extends BackendCall> = T extends (...args: infer P) => any ? NestedRefs<P> : never;
+type BackendCallResponse<T extends BackendCall> = ReturnType<T> extends Promise<infer I> ? I : APIResponse;
 
 /**
  * @example
  * const { data, error } = useBackend(getUserInfo("IdOfUser"))
  */
-export const useBackend = <T>(call: BackendCall<T>, immediately = false) => {
-  const data = shallowRef<APIResponse<T>>();
+export const useBackend = <T extends BackendCall>(call: T, immediately = true, ...params: BackendCallParameters<T>) => {
+  const data = shallowRef<BackendCallResponse<T>>();
   const error = shallowRef<ErrorResponse>();
+  const param = reactive(params);
 
   const refresh = () =>
-    call()
+    call(...param)
       .then((res) => (data.value = res))
       .catch((err) => (error.value = err));
 


### PR DESCRIPTION
従来、`useBackend`はファクトリー関数を引数として実装しているが、
クロージャのせいで、その関数のパラメータはすべて固定されます
しかし、多くの場合は `Ref<T>`型で参照で紐づけている

現在は呼び出しのパラメータは Ref型でもそうでなくても正常に動けます
内側で`Reactive`で`Ref`をラッピングして、
呼び出すタイミングで評価します。