### PR TITLE
chore: :hammer: 開発用サーバーの設定を修正

### DIFF
--- a/web/app/package.json
+++ b/web/app/package.json
@@ -4,7 +4,7 @@
   "description": "未来創造展",
   "scripts": {
     "build": "vite build",
-    "dev": "vite --host"
+    "dev": "vite"
   },
   "repository": {
     "type": "git",

--- a/web/app/vite.config.ts
+++ b/web/app/vite.config.ts
@@ -17,8 +17,4 @@ export default defineConfig({
       },
     },
   },
-  server: {
-    host: true,
-    port: 8080,
-  }
 });


### PR DESCRIPTION
`vite --host` は外側にポートが開きます
`vite.config.js` の `server` 不要です

先のマージに気付かなかった