### PR TITLE
add: .gitattributesで改行コードの制御を追加

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 *.sh    text eol=lf
 
 # Windowsシェル
-*.bat   text eol=crl
+*.bat   text eol=crlf
 *.cmd   text eol=crlf
 *.ps1   text eol=crlf
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# デフォルトの改行コード
+*       text=auto
+
+*.txt   text
+
+# Linuxシェル
+*.sh    text eol=lf
+
+# Windowsシェル
+*.bat   text eol=crl
+*.cmd   text eol=crlf
+*.ps1   text eol=crlf
+
+# 変更すべきでないファイル
+*.png   -text
+*.jpg   -text
+*.jar   -text
+
+# ビルドツールのLinux用シェル
+mvnm    text eol=lf
+gradlew text eol=lf


### PR DESCRIPTION
 .gitattributesファイルを追加して、docker-compose up -dをする際の改行コード問題を解決。これでおそらくshファイルは強制的にLFになる。