### PR TITLE
fix: :adhesive_bandage: `process.env`の使い方

### DIFF
--- a/web/app/lib/auth.ts
+++ b/web/app/lib/auth.ts
@@ -1,4 +1,4 @@
-const { TOKEN_KEY: tokenKey } = process.env;
+const tokenKey = process.env.TOKEN_KEY;
 
 export const setToken = (token?: string) => token && localStorage.setItem(tokenKey, token);
 

--- a/web/app/lib/network.ts
+++ b/web/app/lib/network.ts
@@ -1,7 +1,7 @@
 import { getAuthHeader, setToken } from "./auth";
 
 //#region Prelude
-const { API_SERVER: baseUrl } = process.env;
+const baseUrl = process.env.API_SERVER;
 
 interface AccessOptions {
   method: "GET" | "POST" | "PUT" | "DELETE";


### PR DESCRIPTION
`Process.Env`はdistructしてはいけない、
Viteは解体した環境変数を置換できません