### PR TITLE
fix:ヘッダー調整・読み込み時にアイコン周りでエラーが滅茶苦茶出ていたのを修正

### DIFF
--- a/web/app/component/GlobalHeader/Link.vue
+++ b/web/app/component/GlobalHeader/Link.vue
@@ -4,8 +4,8 @@
       <font-awesome-icon :icon="icon" inverse/>
     </div>
     <div class="link-text-box">
-      <p>{{ linkText }}</p>
-      <p v-if="noticeCount>0">{{ noticeCount }}</p>
+      <p @click="linkClick">{{ linkText }}</p>
+      <div v-if="noticeCount>0" class="notice"><span>{{ noticeCount }}</span></div>
     </div>
   </div>
 
@@ -27,7 +27,8 @@ export default {
       type: String
     }
   },
-  mounted() {
+  // Mount時だと空のiconが代入されてエラーがでまくる
+  beforeMount() {
     switch (this.linkText) {
       case "Profile":
         this.icon = "fa-regular fa-user"
@@ -69,6 +70,35 @@ export default {
     getNoticeCount() {
       // API処理
       this.noticeCount = 4
+    },
+    linkClick: async function () {
+
+      switch (this.linkText) {
+        case "Profile":
+          await this.$router.push("/mypage")
+          break
+        case "Make":
+          await this.$router.push("/create")
+          break;
+        case "Share":
+          break;
+        case "Friend":
+          // friend modal open
+          break;
+        case "Search":
+          // search modal open
+          break;
+        case "Info":
+          // info
+          break;
+
+        case "Logout":
+          await this.$router.push("/logout")
+          break;
+        case "Notice":
+          // notice modal open
+          break;
+      }
     }
   }
 }
@@ -101,6 +131,18 @@ export default {
 .link-text-box p {
   font-size: 18px;
   margin: 0 0 0 16px;
+  color: #ffffff;
+}
+
+.notice{
+  margin-left: 5px;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  background: #FC7474;
   color: #ffffff;
 }
 </style>

--- a/web/app/component/GlobalHeader/Main.vue
+++ b/web/app/component/GlobalHeader/Main.vue
@@ -9,10 +9,9 @@
       <header-link link-text="Friend"/>
       <header-link link-text="Search"/>
       <header-link link-text="Notice"/>
-
     </div>
     <div class="logout-area">
-       <header-link link-text="Logout" />
+      <header-link link-text="Logout"/>
     </div>
 
   </header>
@@ -59,7 +58,7 @@ header {
 }
 
 
-.notice-area {
+.logout-area {
   width: 100%;
   height: 20%;
   display: flex;
@@ -67,8 +66,6 @@ header {
   align-items: flex-start;
   position: relative;
 }
-
-
 
 
 </style>


### PR DESCRIPTION
Mountedでアイコンに渡す引数を設定すると最初の読み込み時点で初期化された空白の値を渡しエラーになっていたのを修正しました。