### PR TITLE
change: フレンド一覧取得を細分化

### DIFF
--- a/back/app/apiv1/urls.py
+++ b/back/app/apiv1/urls.py
@@ -9,7 +9,9 @@ app_name = 'apiv1'
 urlpatterns = [
     path('', include(router.urls)),
     path('friends/apply/<int:user_from>/',
-         views.FriendRequestApplyAPIView.as_view()),
+         views.FriendRequestAnswerAPIView.as_view()),
+    path('friends/apply', views.FriendRequestApplyListAPIView.as_view()),
+    path('friends/request', views.FriendRequestListAPIView.as_view()),
     path('friends/<int:user_to>/', views.FriendDeleteAPIView.as_view()),
     path('friends/', views.FriendListRequestAPIView.as_view()),
     path('brains/share/<int:note>/<int:user_to>/',

--- a/back/app/apiv1/views.py
+++ b/back/app/apiv1/views.py
@@ -41,10 +41,10 @@ class FriendListRequestAPIView(mixins.ListModelMixin, mixins.CreateModelMixin, g
         ログインユーザのユーザIDでフィルタリング
         """
         auth_user_id = self.request.user.id
-        return Friend.objects.filter(Q(user_from=auth_user_id) | Q(user_to=auth_user_id))
+        return Friend.objects.filter(Q(user_from=auth_user_id) | Q(user_to=auth_user_id), apply=True)
 
     def get(self, request, *args, **kwargs):
-        """フレンドリストを取得"""
+        """フレンドリスト（承認済み）を取得"""
         return self.list(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
@@ -52,6 +52,42 @@ class FriendListRequestAPIView(mixins.ListModelMixin, mixins.CreateModelMixin, g
         auth_user_id = self.request.user.id
         request.data['user_from'] = auth_user_id
         return self.create(request, *args, **kwargs)
+
+
+class FriendRequestListAPIView(mixins.ListModelMixin, generics.GenericAPIView):
+    """ログインユーザが申請中のユーザ一覧を取得するAPIクラス"""
+
+    queryset = Friend.objects.all()
+    serializer_class = FriendSerializer
+
+    def get_queryset(self):
+        """
+        ログインユーザのユーザIDでフィルタリング
+        """
+        auth_user_id = self.request.user.id
+        return Friend.objects.filter(user_from=auth_user_id, apply=False, rejection=False)
+
+    def get(self, request, *args, **kwargs):
+        """ログインユーザが申請中のユーザ一覧を取得"""
+        return self.list(request, *args, **kwargs)
+
+
+class FriendRequestApplyListAPIView(mixins.ListModelMixin, generics.GenericAPIView):
+    """ログインユーザの承認待ちのユーザ一覧を取得APIクラス"""
+
+    queryset = Friend.objects.all()
+    serializer_class = FriendSerializer
+
+    def get_queryset(self):
+        """
+        ログインユーザのユーザIDでフィルタリング
+        """
+        auth_user_id = self.request.user.id
+        return Friend.objects.filter(user_to=auth_user_id, apply=False, rejection=False)
+
+    def get(self, request, *args, **kwargs):
+        """ログインユーザの承認待ちのユーザ一覧を取得"""
+        return self.list(request, *args, **kwargs)
 
 
 class FriendDeleteAPIView(mixins.DestroyModelMixin, generics.GenericAPIView):
@@ -75,7 +111,7 @@ class FriendDeleteAPIView(mixins.DestroyModelMixin, generics.GenericAPIView):
         return self.destroy(request, *args, **kwargs)
 
 
-class FriendRequestApplyAPIView(mixins.UpdateModelMixin, generics.GenericAPIView):
+class FriendRequestAnswerAPIView(mixins.UpdateModelMixin, generics.GenericAPIView):
     """ユーザのフレンド申請承認APIクラス"""
 
     serializer_class = FriendSerializer


### PR DESCRIPTION
この[issue](https://github.com/Kazumasa1/memo-re/issues/117)の対応PRです。

以下のようにフレンドリスト一覧機能を細分化しました。

`/api/v1/friends/`：既に承認されたフレンドのリストを取得するエンドポイント
`/api/v1/friends/request`：ログインユーザがフレンド申請中のユーザのリストを取得するエンドポイント
`/api/v1/friends/apply`：ログインユーザの他のユーザからのフレンド申請リストを取得するエンドポイント