### PR TITLE
change: アカウント情報変更にパスワードの整合性チェックを追加

### DIFF
--- a/back/app/accounts/serializers.py
+++ b/back/app/accounts/serializers.py
@@ -12,7 +12,7 @@ class CustomUserSerializer(serializers.UserSerializer):
     class Meta:
         model = CustomUser
         fields = ['id', 'username', 'icon_uri', 'email', 'password', 'tag']
-        read_only_fields = (id,)
+        read_only_fields = ('id',)
         extra_kwargs = {
             'password': {
                 'write_only': True

--- a/back/app/accounts/views.py
+++ b/back/app/accounts/views.py
@@ -1,3 +1,31 @@
 from django.shortcuts import render
+from djoser.views import UserViewSet
+from rest_framework.decorators import action
+from accounts.models import CustomUser
+from rest_framework.response import Response
 
-# Create your views here.
+
+class CustomUserViewSet(UserViewSet):
+
+    @action(["get", "patch", "delete"], detail=False)
+    # @action(["get", "put", "patch", "delete"], detail=False)
+    def me(self, request, *args, **kwargs):
+
+        self.get_object = self.get_instance
+        if request.method == "GET":
+            return self.retrieve(request, *args, **kwargs)
+        # elif request.method == "PUT":
+        #     return self.update(request, *args, **kwargs)
+        elif request.method == "PATCH":
+            # if 'password' in request.data:
+            #     queryset = CustomUser.objects.filter(
+            #         password=request.data['password'])
+            # else:
+            #     return Response(data={'error': 'passwordが未入力です'}, status=500)
+            # if queryset.exists():
+            #     return self.partial_update(request, *args, **kwargs)
+            # else:
+            #     return Response(data={'error': 'passwordが違います'}, status=500)
+            return self.partial_update(request, *args, **kwargs)
+        elif request.method == "DELETE":
+            return self.destroy(request, *args, **kwargs)

--- a/back/app/config/urls.py
+++ b/back/app/config/urls.py
@@ -13,6 +13,7 @@ router.register("api/v1/auth/users", CustomUserViewSet)
 urlpatterns = [
     path('', include(router.urls)),
     path(environ['DJANGO_ADMIN_URL'], admin.site.urls),
+    # path('', TemplateView.as_view(template_name='index.html')),
     path('api/v1/auth/', include('djoser.urls')),
     path('api/v1/auth/', include('djoser.urls.jwt')),
     path('api/v1/auth/', include('rest_framework.urls')),  # DRFのログイン機能を表示

--- a/back/app/config/urls.py
+++ b/back/app/config/urls.py
@@ -4,11 +4,15 @@ from django.contrib import admin
 from django.urls import path, include, re_path
 from django.conf.urls.static import static
 from django.views.generic import TemplateView, RedirectView
+from rest_framework import routers
+from accounts.views import CustomUserViewSet
 
+router = routers.DefaultRouter()
+router.register("api/v1/auth/users", CustomUserViewSet)
 
 urlpatterns = [
+    path('', include(router.urls)),
     path(environ['DJANGO_ADMIN_URL'], admin.site.urls),
-    path('', TemplateView.as_view(template_name='index.html')),
     path('api/v1/auth/', include('djoser.urls')),
     path('api/v1/auth/', include('djoser.urls.jwt')),
     path('api/v1/auth/', include('rest_framework.urls')),  # DRFのログイン機能を表示


### PR DESCRIPTION
#135 の対応MRです。
協議の結果、アイコン画像やユーザ名、タグを変えるだけにパスワード入力は要らないということになったので、コメントアウトしています。
djoserのオーバーライドは今後も使いそうなので、views.py やurls.py の変更は残しておきます。