### PR TITLE
add: ユーザ検索機能のエンドポイントを追加

### DIFF
--- a/back/app/apiv1/urls.py
+++ b/back/app/apiv1/urls.py
@@ -8,6 +8,7 @@ router = routers.DefaultRouter()
 app_name = 'apiv1'
 urlpatterns = [
     path('', include(router.urls)),
+    path('search/', views.SearchUserAPIView.as_view()),
     path('friends/apply/<int:user_from>/',
          views.FriendRequestAnswerAPIView.as_view()),
     path('friends/apply/', views.FriendRequestApplyListAPIView.as_view()),

--- a/back/app/apiv1/views.py
+++ b/back/app/apiv1/views.py
@@ -44,8 +44,7 @@ class SearchUserAPIView(mixins.ListModelMixin, generics.GenericAPIView):
 
     def get_queryset(self):
         """
-        Optionally restricts the returned purchases to a given user,
-        by filtering against a `username` query parameter in the URL.
+        検索項目で渡されたクエリパラメータでフィルタリング
         """
         queryset = CustomUser.objects.all()
         get_query = self.request.query_params.getlist('get', None)

--- a/back/app/apiv1/views.py
+++ b/back/app/apiv1/views.py
@@ -39,8 +39,6 @@ class SearchUserAPIView(mixins.ListModelMixin, generics.GenericAPIView):
     """ユーザ検索用APIクラス"""
 
     serializer_class = CustomUserSerializer
-    # queryset = CustomUser.objects.all()
-    # filter_backends = [filters.DjangoFilterBackend]
 
     def get_queryset(self):
         """


### PR DESCRIPTION
#118 の対応PRです。
`api/v1/search`で`?get=`+ 検索したい文字列 で検索できるように実装しました。
複数検索だと、
`api/v1/search?get=猿&get=天才`というように＆で連結します。

検索にヒットするフィールドは、

- id（ユーザのID）
- username（ユーザ名）
- tag

です。