### PR TITLE
fix: ノート申請の援受を判別できるように修正

### DIFF
--- a/back/app/apiv1/serializers.py
+++ b/back/app/apiv1/serializers.py
@@ -78,8 +78,8 @@ class NoteListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Note
-        fields = ('id', 'image_uri',)
-        read_only_fields = ('id', 'image_uri',)
+        fields = ('id', 'user_id', 'image_uri',)
+        read_only_fields = ('id', 'user_id', 'image_uri',)
 
 
 class NoteEditSerializer(serializers.ModelSerializer):
@@ -111,6 +111,6 @@ class NoteShareListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = NoteShare
-        fields = ('user_from', 'user_to', 'note', 'notified',
+        fields = ('user_from', 'user_to', 'note', 'get', 'notified',
                   'apply', 'rejection', 'register_at',)
         read_only_fields = ('note', 'user_from', 'user_to', 'register_at',)

--- a/back/app/memore/models.py
+++ b/back/app/memore/models.py
@@ -158,6 +158,10 @@ class NoteShare(models.Model):
         related_name="noteshare_note_id",
         on_delete=models.CASCADE,
     )
+    get = models.BooleanField(
+        _("もらう"),
+        default=True,
+    )
     notified = models.BooleanField(
         _("通知"),
         default=True,


### PR DESCRIPTION
#232 の対応PRです。

ノート共有モデルにgetフィールドを追加して、もらう申請をしたユーザがわかるようにしました。